### PR TITLE
Support to multi database exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ Next, run this command:
 - `composer require bythepixel/laravel-source-seeder`
 
 ## Export Seeder Source Files (.json)
-- `php artisan seeder:build {table?}`
+- `php artisan seeder:build {table?} {--connection=}`
 - Generates .json files for all relevant tables (or as passed in by the table parameter)
 - This command will typically be executed on a production environment to export "real" production data
 - Once files have been generated they can be committed to the repository allowing new environments to be up to date
 - If executed on a remote environment, `scp` is recommended to copy the json files
   - `scp -rp ./database/seeders/Source <user>@<public_ip>:/srv/www/database/seeders/Source`
-  
+- When a connection is specified, the seeder will use that connection to export data. The file will be stored in the 
+  `database/seeders/Source/{connection}` directory.
   
 ## Example Seeder Class Implementation
 Path: `database/seeders/LocationSeeder.php`

--- a/src/Console/Commands/BuildSeederSourceFiles.php
+++ b/src/Console/Commands/BuildSeederSourceFiles.php
@@ -9,7 +9,7 @@ use League\Flysystem\Filesystem;
 
 class BuildSeederSourceFiles extends Command
 {
-    protected $signature = 'seeders:build {table?}';
+    protected $signature = 'seeders:build {table?} {--connection= : The database connection to use}';
 
     protected $description = 'Build source files for specified table. If no parameter is passed, all versioned database tables will be built.';
 
@@ -20,7 +20,8 @@ class BuildSeederSourceFiles extends Command
     public function handle()
     {
         $targetTable = $this->argument('table');
-        $fs = new Filesystem(new Local(database_path('seeders/Source')));
+        $path = $this->getSourcePath();
+        $fs = new Filesystem(new Local($path));
 
         $tables = $targetTable === null ? $this->tables : [$targetTable];
 
@@ -32,7 +33,8 @@ class BuildSeederSourceFiles extends Command
     private function buildTable(string $table, Filesystem $sourceFs)
     {
         $data = [];
-        $result = DB::table($table)->get('*');
+        $connection = $this->option('connection') ?: config('database.default');
+        $result = DB::connection($connection)->table($table)->get('*');
 
         foreach ($result as $row) {
             $data[] = (array)$row;
@@ -48,5 +50,15 @@ class BuildSeederSourceFiles extends Command
         $sourceFs->put("$table.json", $json);
 
         $this->info("Successfully built seeder for $table");
+    }
+
+    private function getSourcePath(): string
+    {
+        $path = database_path('seeders/Source');
+        if ($this->hasOption('connection')) {
+            $path .= DIRECTORY_SEPARATOR . $this->option('connection');
+        }
+
+        return $path;
     }
 }

--- a/src/SourceSeederInternal.php
+++ b/src/SourceSeederInternal.php
@@ -25,13 +25,15 @@ class SourceSeederInternal extends Seeder
 
     public function run()
     {
-        $fs = new Filesystem(new Local(database_path('seeders/Source')));
+        $path = $this->getSourcePath();
+
+        $fs = new Filesystem(new Local($path));
         $type = $this->getType();
 
         try {
             $json = $fs->read("$type.json");
         } catch (\Exception $e) {
-            $message = "Warning: Seeder Source does not exist for $type";
+            $message = "Warning: Seeder Source does not exist for $type at $path";
             Log::warning($message);
             echo "$message\n";
             return;
@@ -52,5 +54,16 @@ class SourceSeederInternal extends Seeder
                 DB::table($type)->insert($row);
             }
         }
+    }
+
+    private function getSourcePath(): string
+    {
+        $path = 'seeders/Source';
+        if ($this->command->hasOption('database')) {
+            $connection = $this->command->option('database');
+            $path .= DIRECTORY_SEPARATOR . $connection;
+        }
+
+        return $path;
     }
 }


### PR DESCRIPTION
Related task: https://app.clickup.com/t/30963010/TW-7169

# Fixes, Changes, Additions, Removals (What)
- Updates SourceSeederInternal class to use the connection passed to the seeder command
- Updates BuildSeederSourceFiles to use a connection and store files in sub directory with the connection name

# Implementation Reasoning (Why)
- Multi tenancy applications that use a multi database approach benefit greatly from storing different seeder files

# Impacted Areas (Where)
- Artisan command
- Base class that seeders extend